### PR TITLE
Multi-architecture builds are overwriting each other

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,7 @@ jobs:
           - ./build.sh feature
           - ./build.sh develop
         platform:
-          - linux/amd64
-          - linux/arm64
+          - linux/amd64,linux/arm64
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new NetBox Docker Images


### PR DESCRIPTION
So we end up with just the arm64 images in ghcr.io repository, since they are the slowest to build.

Resynchronise the 'platforms' section in the workflow with upstream. It's not a list of architectures, one per list entry.  It's a single list entry mentioning all architectures.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [ ] I have read the comments and followed the PR template.
* [ ] My PR targets the `develop` branch.
