### PR TITLE
Don't try and build containers for prerelease versions of netbox

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         build_cmd:
           - ./build-latest.sh
-          - PRERELEASE=true ./build-latest.sh
+          #- PRERELEASE=true ./build-latest.sh
           - ./build.sh develop
         platform:
           - linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         build_cmd:
           - ./build-latest.sh
-          - PRERELEASE=true ./build-latest.sh
+          #- PRERELEASE=true ./build-latest.sh
           - ./build.sh develop
         platform:
           - linux/amd64,linux/arm64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   netbox: &netbox
-    image: ghcr.io/oxcert/netbox:${VERSION-v3.7-1.2.0}
+    image: ghcr.io/oxcert/netbox:${VERSION-v3.7-1.2.1}
     depends_on:
     - postgres
     - redis


### PR DESCRIPTION
The netbox_dns plugin is currently incompatible with docker-4.0: see

https://github.com/peteeckel/netbox-plugin-dns/releases/tag/1.0-beta1

So, in the mean time only build our containers pre-seeded with the netbox_dns plugin for the current relese version(s) of netbox.  We never want to run the pre-release version of netbox in any case.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] My PR targets the `develop` branch.
